### PR TITLE
catch divide by zero in ratio computation

### DIFF
--- a/lqp_py/solve_box_qp_admm_torch.py
+++ b/lqp_py/solve_box_qp_admm_torch.py
@@ -226,7 +226,7 @@ def torch_solve_box_qp(Q, p, A, b, lb, ub, control):
             update_rho_1 = (ratio > adaptive_rho_tol).sum() > 0
             update_rho_2 = (ratio < (1 / adaptive_rho_tol)).sum() > 0
             update_rho = update_rho_1.item() or update_rho_2.item()
-            if update_rho:
+            if update_rho and ratio.isfinite().all():
                 rho_new = rho * ratio
                 rho = rho * is_optimal + rho_new * torch.logical_not(is_optimal)
                 rho = torch.clamp(rho, min=rho_min, max=rho_max)


### PR DESCRIPTION
Hello, 
Thanks for writing this libary, its great. However i run into an issue when solving simple constrained least squares problems. Depending on the samples in a batch it can happen that rho is updated even tho `tol_dual_rel_norm` is 0 for one of the samples. This leads to nan values because we divide by 0. I fixed this by simply checking for nans before updating rho. 

If there is a smarter way to prevent this please let me know